### PR TITLE
Fix: Telegram Link in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@
 
 <p align="center">
   <a href="https://github.com/SudiptaPaul-31"><img src="https://img.shields.io/badge/EXPLORATION_TEAM-212121?style=for-the-badge" alt="EXPLORATION TEAM"></a>
-  <a href="https://t.me/bitcoinwildlife"><img src="https://img.shields.io/badge/TELEGRAM-26A5E4?style=for-the-badge&logo=telegram&logoColor=white" alt="TELEGRAM"></a>
+  <a href="https://t.me/snipu_code"><img src="https://img.shields.io/badge/TELEGRAM-26A5E4?style=for-the-badge&logo=telegram&logoColor=white" alt="TELEGRAM"></a>
 </p>
 
 ## Overview


### PR DESCRIPTION
- Closes: #22 
- Telegram link correctly redirects to the Snipu TG group