### PR TITLE
add loading component for snippets (closes #98)

### DIFF
--- a/src/app/snippet/[id]/loading.tsx
+++ b/src/app/snippet/[id]/loading.tsx
@@ -1,7 +1,8 @@
 import React from "react";
+import Loading from "@/app/snippet/loading";
 
 const loading = () => {
-  return <div className="text-white">Loading...</div>;
+  return <div className="text-white"><Loading /></div>;
 };
 
 export default loading;

--- a/src/app/snippet/loading.tsx
+++ b/src/app/snippet/loading.tsx
@@ -1,4 +1,10 @@
+import React from 'react';
+import { Loader2 } from 'lucide-react';
+
 export default function Loading() {
-    return null
-  }
-  
+  return (
+    <span className="flex flex-col items-center justify-center mt-16">
+      <Loader2 className="size-8 animate-spin text-primary" color="#a855f7"/>
+    </span>
+  );
+}


### PR DESCRIPTION
Added loading component that matches with site color scheme. The circle spins while visible and is centered, with some margin set on the top.
![image](https://github.com/user-attachments/assets/591f9a2a-391e-4f17-b83f-f7f92607693d)
