### PR TITLE
Enabled immutable version tracking of snippets

### DIFF
--- a/contracts/src/interfaces/isnippet_storage.cairo
+++ b/contracts/src/interfaces/isnippet_storage.cairo
@@ -24,4 +24,6 @@ pub trait ISnippetStorage<TContractState> {
     fn get_reaction_count(self: @TContractState, snippet_id: felt252) -> u256;
     fn get_reactions(self: @TContractState, snippet_id: felt252) -> ReactionDetails;
     fn get_user_reaction(self: @TContractState, snippet_id: felt252) -> u8;
+    fn add_version(ref self: TContractState, snippet_id: felt252, snippet_hash: felt252);
+    fn get_versions(self: @TContractState, snippet_id: felt252) -> Array<felt252>;
 }

--- a/contracts/tests/test_snippet_storage.cairo
+++ b/contracts/tests/test_snippet_storage.cairo
@@ -444,3 +444,50 @@ fn test_snippet_add_comment_should_panic_on_invalid_snippet_id() {
 
     contract.add_comment(snippet_id, 'comment');
 }
+
+#[test]
+fn test_add_and_get_versions() {
+    let contract = init_contract();
+    let snippet_id = 42;
+    let content = 123;
+
+    start_cheat_caller_address(contract.contract_address, user_a());
+    contract.add_snippet(snippet_id, content);
+    
+    // Add versions
+    contract.add_version(snippet_id, 456);
+    contract.add_version(snippet_id, 789);
+    
+    let versions = contract.get_versions(snippet_id);
+    assert(versions.len() == 2, 'Should have 2 versions');
+    assert(*versions.at(0) == 456, 'First version mismatch');
+    assert(*versions.at(1) == 789, 'Second version mismatch');
+    stop_cheat_caller_address(contract.contract_address);
+}
+
+#[test]
+#[should_panic(expected: 'Not authorized')]
+fn test_add_version_unauthorized() {
+    let contract = init_contract();
+    let snippet_id = 42;
+    let content = 123;
+
+    start_cheat_caller_address(contract.contract_address, user_a());
+    contract.add_snippet(snippet_id, content);
+    stop_cheat_caller_address(contract.contract_address);
+
+    start_cheat_caller_address(contract.contract_address, user_b());
+    contract.add_version(snippet_id, 456); // Should panic
+    stop_cheat_caller_address(contract.contract_address);
+}
+
+#[test]
+#[should_panic(expected: 'Snippet not found')]
+fn test_add_version_nonexistent_snippet() {
+    let contract = init_contract();
+    let snippet_id = 42;
+
+    start_cheat_caller_address(contract.contract_address, user_a());
+    contract.add_version(snippet_id, 456); // Should panic
+    stop_cheat_caller_address(contract.contract_address);
+}


### PR DESCRIPTION
# Pull Request Template

## 📋 Description

This PR implements immutable version tracking for snippets by introducing a versioning system that allows users to track historical versions of their code snippets. The implementation includes new storage structures, methods for adding and retrieving versions, and proper event emission.

## 🔗 Related Issue

Closes #125 

## 🎯 Type of Change

- [x] ✨ New feature (non-breaking change which adds functionality)
- [x] 🧪 Test addition or update

## 🧪 Testing

- [x] I have tested my changes locally
- [x] I have tested the blockchain integration
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

### Tests Added:
- `test_add_and_get_versions` - Tests basic version functionality
- `test_add_version_unauthorized` - Tests authorization checks
- `test_add_version_nonexistent_snippet` - Tests error handling for non-existent snippets

## 📸 Screenshots/Videos

*N/A - This is a smart contract feature without UI changes*

## 📝 Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have checked my code and corrected any misspellings
- [x] I have read the [CONTRIBUTING.md](../CONTRIBUTING.md) file

## 🔧 Technical Details

### Changes Made
- Added `version_count` and `versions` storage maps to track snippet versions
- Implemented `add_version` method with proper authorization checks
- Implemented `get_versions` method to retrieve version history
- Added `SnippetVersionAdded` event for version tracking
- Added comprehensive test coverage

### Files Modified
- `contracts/src/interfaces/isnippet_storage.cairo` - Added interface methods
- `contracts/src/snippet_storage.cairo` - Implemented versioning functionality
- `contracts/tests/test_snippet_storage.cairo` - Added test cases

### Dependencies Added/Removed
- None - No new dependencies required

### Smart Contract Changes
- **New Storage**: Added `version_count: Map<felt252, u32>` and `versions: Map<(felt252, u32), felt252>`
- **New Methods**: `add_version()` and `get_versions()`
- **New Event**: `SnippetVersionAdded` with snippet_id, snippet_hash, and timestamp
- **Security**: Proper authorization checks to ensure only snippet owners can add versions

## 🚀 Deployment Notes

- This is a non-breaking change that adds new functionality
- Existing storage layout remains unchanged
- New methods can be safely added to the interface

## 📊 Performance Impact

- Minimal performance impact as version storage uses efficient mapping
- Version retrieval is O(n) where n is the number of versions for a snippet
- Storage costs are predictable and linear to the number of versions stored

## 🔒 Security Considerations

- Only snippet owners can add new versions (proper authorization checks)
- Version data is immutable once stored
- No sensitive data exposure through version retrieval

## 🌐 Browser/Device Testing

*N/A - Backend/smart contract feature only*

## 📱 Mobile Responsiveness

*N/A - Backend/smart contract feature only*

## 🔗 Additional Links

*N/A*

## 📝 Additional Notes

The versioning system provides:
1. **Immutable tracking**: Once a version is added, it cannot be modified
2. **Chronological ordering**: Versions are stored in the order they were added
3. **Efficient retrieval**: Quick access to all versions of a snippet
4. **Event logging**: Proper blockchain event emission for external tracking

## ⚠️ Breaking Changes

None - This is a purely additive feature that doesn't affect existing functionality.

## 🎉 Summary

Implemented a robust versioning system for code snippets that allows users to track historical versions of their code, providing immutable version history with proper authorization and event logging.