### PR TITLE
Add trending snippets functionality

### DIFF
--- a/contracts/src/interfaces/isnippet_storage.cairo
+++ b/contracts/src/interfaces/isnippet_storage.cairo
@@ -26,4 +26,6 @@ pub trait ISnippetStorage<TContractState> {
     fn get_user_reaction(self: @TContractState, snippet_id: felt252) -> u8;
     fn add_version(ref self: TContractState, snippet_id: felt252, snippet_hash: felt252);
     fn get_versions(self: @TContractState, snippet_id: felt252) -> Array<felt252>;
+
+    fn get_trending_snippets(self: @TContractState, limit: u32) -> Array<(felt252, u256)>;
 }

--- a/contracts/src/snippet_storage.cairo
+++ b/contracts/src/snippet_storage.cairo
@@ -3,25 +3,25 @@ pub mod SnippetStorage {
     use core::array::ArrayTrait;
     use core::starknet::storage::Map;
     use starknet::storage::{
-        StorageMapReadAccess, StorageMapWriteAccess, StoragePathEntry, StoragePointerReadAccess,
-        StoragePointerWriteAccess,
+        MutableVecTrait, StorageMapReadAccess, StorageMapWriteAccess, StoragePathEntry,
+        StoragePointerReadAccess, StoragePointerWriteAccess, Vec, VecTrait,
     };
-    use crate::interfaces::isnippet_storage::ISnippetStorage;
-
-    use starknet::storage::{StorageMapReadAccess, StorageMapWriteAccess};
     use starknet::{
         ContractAddress, contract_address_const, get_block_timestamp, get_caller_address,
     };
+    use crate::interfaces::isnippet_storage::ISnippetStorage;
 
     const ERR_NOT_AUTHORIZED: felt252 = 'Not authorized';
     const ERR_SNIPPET_NOT_FOUND: felt252 = 'Snippet not found';
     const ERR_SNIPPET_EXISTS: felt252 = 'Snippet ID already exists';
     const ERR_INVALID_REACTION: felt252 = 'Invalid reaction';
+    const ERR_LIMIT_EXCEEDED: felt252 = 'Limit exceeded';
 
     #[storage]
     struct Storage {
         owner: ContractAddress,
         user_snippets: Map<ContractAddress, felt252>,
+        all_snippets_ids: Vec<felt252>,
         snippet_store: Map<felt252, felt252>,
         snippet_owner: Map<felt252, ContractAddress>,
         user_snippet_count: Map<ContractAddress, u32>,
@@ -45,9 +45,9 @@ pub mod SnippetStorage {
 
     #[derive(Drop, starknet::Event)]
     pub struct SnippetVersionAdded {
-    snippet_id: felt252,
-    snippet_hash: felt252,
-    timestamp: u64,
+        snippet_id: felt252,
+        snippet_hash: felt252,
+        timestamp: u64,
     }
 
 
@@ -142,6 +142,7 @@ pub mod SnippetStorage {
             self.user_snippet_ids.write((caller, count), snippet_id);
             self.user_snippet_index.write((caller, snippet_id), count);
             self.user_snippet_count.write(caller, count + 1);
+            self.all_snippets_ids.push(snippet_id);
             self.emit(SnippetAdded { snippet_id: snippet_id, snippet: snippet });
         }
 
@@ -172,6 +173,67 @@ pub mod SnippetStorage {
             self.emit(SnippetUpdated { snippet_id: snippet_id, new_snippet: new_snippet });
         }
 
+        fn get_trending_snippets(self: @ContractState, limit: u32) -> Array<(felt252, u256)> {
+            let mut snippets_with_reactions: Array<(felt252, u256)> = array![];
+            assert(limit.into() <= self.all_snippets_ids.len(), ERR_LIMIT_EXCEEDED);
+
+            for i in 0..self.all_snippets_ids.len() {
+                let snippet_id = self.all_snippets_ids.at(i).read();
+                let total_likes: u256 = self.snippet_reactions_storage.read(snippet_id).like;
+                snippets_with_reactions
+                    .append((snippet_id, total_likes + self.get_comments(snippet_id).len().into()));
+            }
+
+            let arr_len = snippets_with_reactions.len();
+
+            if arr_len == 0 {
+                return array![];
+            }
+            if arr_len == 1 {
+                let (id, count) = *snippets_with_reactions.at(0);
+                return array![(id, count)];
+            }
+
+            let mut idx1 = 0;
+            let mut idx2 = 1;
+            let mut sorted_iteration = true;
+            let mut sorted_array: Array<(felt252, u256)> = array![];
+
+            loop {
+                if idx2 == snippets_with_reactions.len() {
+                    sorted_array.append(*snippets_with_reactions.at(idx1));
+                    if sorted_iteration {
+                        break;
+                    }
+                    snippets_with_reactions = sorted_array.span().try_into().unwrap();
+                    sorted_array = array![];
+                    idx1 = 0;
+                    idx2 = 1;
+                    sorted_iteration = true;
+                } else {
+                    let (id1, count1) = *snippets_with_reactions.at(idx1);
+                    let (id2, count2) = *snippets_with_reactions.at(idx2);
+                    if count1 >= count2 {
+                        sorted_array.append((id1, count1));
+                        idx1 = idx2;
+                        idx2 += 1;
+                    } else {
+                        sorted_array.append((id2, count2));
+                        idx2 += 1;
+                        sorted_iteration = false;
+                    }
+                };
+            }
+
+            let mut sorted_array_with_limit: Array<(felt252, u256)> = array![];
+
+            for i in 0..limit {
+                sorted_array_with_limit.append(*sorted_array.at(i));
+            }
+
+            sorted_array_with_limit
+        }
+
         fn add_comment(ref self: ContractState, snippet_id: felt252, content: felt252) {
             let caller = get_caller_address();
             let timestamp: felt252 = get_block_timestamp().into(); // Convert u64 to felt252
@@ -198,7 +260,7 @@ pub mod SnippetStorage {
             for i in 0..count {
                 let comment = self.comments.read((snippet_id, i + 1));
                 comments.append(comment);
-            };
+            }
             comments
         }
 
@@ -339,18 +401,19 @@ pub mod SnippetStorage {
         fn add_version(ref self: ContractState, snippet_id: felt252, snippet_hash: felt252) {
             let caller = get_caller_address();
             let owner = self.snippet_owner.read(snippet_id);
-            assert(owner == caller, ERR_NOT_AUTHORIZED);
             assert(self.snippet_store.read(snippet_id) != 0, ERR_SNIPPET_NOT_FOUND);
+            assert(owner == caller, ERR_NOT_AUTHORIZED);
 
             let count = self.version_count.read(snippet_id);
             self.versions.write((snippet_id, count), snippet_hash);
             self.version_count.write(snippet_id, count + 1);
 
-            self.emit(SnippetVersionAdded {
-                snippet_id,
-                snippet_hash,
-                timestamp: get_block_timestamp(),
-            });
+            self
+                .emit(
+                    SnippetVersionAdded {
+                        snippet_id, snippet_hash, timestamp: get_block_timestamp(),
+                    },
+                );
         }
         fn get_versions(self: @ContractState, snippet_id: felt252) -> Array<felt252> {
             let count = self.version_count.read(snippet_id);
@@ -358,7 +421,7 @@ pub mod SnippetStorage {
             let mut i = 0;
             loop {
                 if i >= count {
-                    break versions;
+                    break versions.clone();
                 }
                 let version_hash = self.versions.read((snippet_id, i));
                 versions.append(version_hash);


### PR DESCRIPTION
Introduce a method to retrieve trending snippets based on user reactions, along with necessary data structures and error handling. Include tests to ensure functionality works as intended.

closes #127